### PR TITLE
adding plugin support via a new "plugins" input parameter

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,9 @@ branding:
   icon: 'terminal'
   color: 'blue'
 inputs:
+  plugins:
+    description: "A comma-separated list of plugins to be installed, if not already present"
+    required: false
   version:
     description: Version of CLI to be installed
     required: false
@@ -40,4 +43,18 @@ runs:
       shell: bash
       run: |
         echo "CLI Installed with version: $(sf --version)"
+
+    - name: Install plugins
+      shell: bash 
+      run: |
+        # Installs the provided list of plugins, if not already installed in the cached sf cli:
+        IFS=',' read -ra PLUGINS <<< "${{ inputs.plugins }}"
+        for plugin in "${PLUGINS[@]}"; do
+          if ! sf plugins --core --json | grep -q "\"name\": \"${plugin}\""; then
+            echo "Installing ${plugin}..."
+            echo y | sf plugins install "${plugin}" --silent
+          else
+            echo "${plugin} is already installed"
+          fi
+        done
 


### PR DESCRIPTION
Adds caching & installation support for SF CLI plugins. 

This is done via a new optional input parameter called `plugins`, which is expected to be a comma-separated list:

```yml
- name: Install CLI & Plugins
  uses: patrykacc/sf-cli-setup@v1.1.0
  with: 
    plugins: "sfdx-git-delta,code-analyzer,lightning-flow-scanner"
```

These plugins aren't stored in a file/directory, so they can't be cached in the same way as the `sf` cli. However, a cached implementation of the CLI may include plugins. In this scenario, the action will not install the plugin. If the plugin isn't installed, the action will install it. 

Note: Some health checks failing,  but this appears to be unrelated/happening with the original branch as well. 